### PR TITLE
Fixed: variable unmatch in shell_scripts

### DIFF
--- a/shell_scripts/run_eval_ppl.sh
+++ b/shell_scripts/run_eval_ppl.sh
@@ -21,4 +21,4 @@ python scripts/eval_ppl.py \
     --seqlen 4096 \
     --datasets wikitext2 c4 \
     --device $DEVICE \
-    --output-path $OUTPUT_FILENAME
+    --output_path $OUTPUT_FILENAME

--- a/shell_scripts/run_eval_zeroshot.sh
+++ b/shell_scripts/run_eval_zeroshot.sh
@@ -20,4 +20,4 @@ python scripts/eval_zero_shot.py \
     --tasks winogrande rte piqa arc_easy arc_challenge \
     --base_model $BASE_MODEL \
     --batch_size 8 \
-    --output-path $OUTPUT_FILENAME
+    --output_path $OUTPUT_FILENAME

--- a/shell_scripts/run_quantize_save_caldera.sh
+++ b/shell_scripts/run_quantize_save_caldera.sh
@@ -33,7 +33,7 @@ QUANT_PARAMS="--Q_bits 2 \
     --activation_aware_LR true \
     --activation_aware_Q true \
     --hadamard_transform true \
-    --iters $CALIBRATION_SIZE \
+    --iters $CALDERA_ITERS \
     --lplr_iters $LPLR_ITERS \
     --rand_svd true \
     --update_order LR Q \
@@ -44,5 +44,5 @@ python scripts/quantize_save_llama.py \
     --hessian_save_path $HESSIAN_SAVE_DIR \
     --model_save_path $CALDERA_MODEL_SAVE_PATH \
     --devices $DEVICES \
-    --base_model $HF_MODEL \
+    --base_model $BASE_MODEL \
     $QUANT_PARAMS


### PR DESCRIPTION
- In the scripts run_eval_ppl.sh and run_eval_zeroshot.sh, the `--output-path` argument caused parsing failures, so it was changed to `--output_path`.
- In the script run_quantize_save_caldera.sh, `CALIBRATION_SIZE` and `HF_MODEL` were undefined, so they were replaced with `CALDERA_ITERS` and `BASE_MODEL`.